### PR TITLE
Stop button

### DIFF
--- a/ipympl/backend_nbagg.py
+++ b/ipympl/backend_nbagg.py
@@ -152,7 +152,12 @@ class Canvas(DOMWidget, FigureCanvasWebAggCore):
 
     header_visible = Bool(True).tag(sync=True)
 
+    width = Float(0, read_only=True).tag(sync=True)
+    height = Float(0, read_only=True).tag(sync=True)
+
     _closed = Bool(True)
+    closed = Bool(False, read_only=True).tag(sync=True)
+    _data_url = Unicode(None, allow_none=True, read_only=True).tag(sync=True)
 
     # Must declare the superclass private members.
     _png_is_old = Bool()
@@ -174,9 +179,7 @@ class Canvas(DOMWidget, FigureCanvasWebAggCore):
 
     def _handle_message(self, object, content, buffers):
         # Every content has a "type".
-        if content['type'] == 'closing':
-            self._closed = True
-        elif content['type'] == 'initialized':
+        if content['type'] == 'initialized':
             _, _, w, h = self.figure.bbox.bounds
             self.manager.resize(w, h)
         else:

--- a/js/src/toolbar_widget.js
+++ b/js/src/toolbar_widget.js
@@ -44,6 +44,19 @@ var ToolbarView = widgets.DOMWidgetView.extend({
         icon.classList = 'center fa fa-bars';
         this.toggle_button.appendChild(icon);
 
+        this.stop_button = document.createElement('button');
+
+        this.stop_button.classList = 'jupyter-matplotlib-button jupyter-widgets jupyter-button mod-danger';
+        this.stop_button.setAttribute('href', '#');
+        this.stop_button.setAttribute('title', 'Stop Interactions and embed');
+        this.stop_button.style.outline = 'none';
+        this.stop_button.addEventListener('click', this.handle_stop.bind(this));
+
+        var close_icon = document.createElement('i');
+        close_icon.classList = 'center fa fa-times';
+        this.stop_button.appendChild(close_icon);
+
+        this.el.appendChild(this.stop_button);
         this.el.appendChild(this.toggle_button);
         this.toolbar = document.createElement('div');
         this.toolbar.classList = 'widget-container widget-box';
@@ -150,6 +163,10 @@ var ToolbarView = widgets.DOMWidgetView.extend({
         // Toggle the interactivity of the figure.
         var visible = this.toolbar.style.display !== 'none';
         this.toolbar.style.display = visible ? 'none' : '';
+    },
+
+    handle_stop: function() {
+        this.trigger('close');
     },
 
     model_events: function() {


### PR DESCRIPTION
This should fix #150 and fix #16 

It adds a "Stop interactions and embed" button which allows saving the plot as a static image in the Notebook. The output actually stays a widget, which has the last state of the plot in its model.

![embed](https://user-images.githubusercontent.com/21197331/75247105-791dd100-57d1-11ea-8c28-aa525fe2e3b6.gif)
