### PR TITLE
Add eslint, prettier, and re-format JS

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,16 @@
+name: Linting
+on: [pull_request]
+
+jobs:
+  eslint:
+    name: eslint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: eslint
+        uses: reviewdog/action-eslint@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-check
+          workdir: 'js'

--- a/js/.eslintrc.js
+++ b/js/.eslintrc.js
@@ -1,0 +1,21 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    commonjs: true,
+    es2017: true,
+  },
+  extends: ["eslint:recommended", "prettier"],
+  parserOptions: {
+    ecmaVersion: 9,
+    sourceType: "module",
+  },
+  rules: {
+    "no-unused-vars": [
+      "error",
+      {
+        argsIgnorePattern: "^_",
+      },
+    ],
+  },
+};

--- a/js/.prettierrc
+++ b/js/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "overrides": [
+    {
+      "files": ["webpack.config.js", "src/**/*.js"],
+      "options": {
+        "singleQuote": true,
+        "tabWidth": 4,
+      }
+    }
+  ]
+}

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -4,6 +4,32 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.8.3"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.9.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+      "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+      "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.9.0",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
     "@jupyter-widgets/base": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@jupyter-widgets/base/-/base-2.0.1.tgz",
@@ -191,6 +217,12 @@
         "@types/jquery": "*",
         "@types/underscore": "*"
       }
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
     },
     "@types/jquery": {
       "version": "3.3.30",
@@ -409,6 +441,12 @@
       "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
       "dev": true
     },
+    "acorn-jsx": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+      "dev": true
+    },
     "ajv": {
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
@@ -431,6 +469,23 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
       "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
       "dev": true
+    },
+    "ansi-escapes": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.11.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "dev": true
+        }
+      }
     },
     "ansi-regex": {
       "version": "4.1.0",
@@ -463,6 +518,15 @@
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -530,6 +594,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
     "async-each": {
@@ -834,6 +904,12 @@
         "unset-value": "^1.0.0"
       }
     },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -861,6 +937,12 @@
           }
         }
       }
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
     },
     "chokidar": {
       "version": "3.4.0",
@@ -965,6 +1047,21 @@
           }
         }
       }
+    },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+      "dev": true
     },
     "cliui": {
       "version": "5.0.0",
@@ -1241,6 +1338,12 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -1307,6 +1410,15 @@
         "bn.js": "^4.1.0",
         "miller-rabin": "^4.0.0",
         "randombytes": "^2.0.0"
+      }
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
       }
     },
     "domain-browser": {
@@ -1401,6 +1513,99 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "eslint": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.4.3",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.2",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^7.0.0",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.14",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.3",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "eslint-scope": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-config-prettier": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
+      "integrity": "sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      }
+    },
     "eslint-scope": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -1409,6 +1614,63 @@
       "requires": {
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "dev": true
+    },
+    "espree": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+          "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
+          "dev": true
+        }
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
+          "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
+          "dev": true
+        }
       }
     },
     "esrecurse": {
@@ -1424,6 +1686,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
     "events": {
@@ -1522,6 +1790,17 @@
         }
       }
     },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
     "extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -1597,11 +1876,35 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
     "figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
       "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
       "dev": true
+    },
+    "figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
     },
     "fill-range": {
       "version": "4.0.0",
@@ -1657,6 +1960,23 @@
         "micromatch": "^3.0.4",
         "resolve-dir": "^1.0.1"
       }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      }
+    },
+    "flatted": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "dev": true
     },
     "flush-write-stream": {
       "version": "1.1.1",
@@ -1729,10 +2049,22 @@
       "dev": true,
       "optional": true
     },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
     },
     "get-stream": {
@@ -1769,7 +2101,6 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
       "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -1807,6 +2138,15 @@
         "ini": "^1.3.4",
         "is-windows": "^1.0.1",
         "which": "^1.2.14"
+      }
+    },
+    "globals": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.1"
       }
     },
     "graceful-fs": {
@@ -1899,6 +2239,15 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
     "icss-utils": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
@@ -1919,6 +2268,30 @@
       "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
+      }
     },
     "import-local": {
       "version": "2.0.0",
@@ -1969,6 +2342,123 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
+    },
+    "inquirer": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^3.0.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.5.3",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "interpret": {
       "version": "1.2.0",
@@ -2154,6 +2644,22 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
       "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
     "json-loader": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
@@ -2170,6 +2676,12 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -2193,6 +2705,16 @@
       "dev": true,
       "requires": {
         "invert-kv": "^2.0.0"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "loader-runner": {
@@ -2455,6 +2977,12 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -2473,6 +3001,12 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
       }
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
     },
     "neo-async": {
       "version": "2.6.1",
@@ -2609,6 +3143,29 @@
         "wrappy": "1"
       }
     },
+    "onetime": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      }
+    },
     "os-browserify": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
@@ -2625,6 +3182,12 @@
         "lcid": "^2.0.0",
         "mem": "^4.0.0"
       }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "p-defer": {
       "version": "1.0.0",
@@ -2683,6 +3246,15 @@
         "cyclist": "^1.0.1",
         "inherits": "^2.0.3",
         "readable-stream": "^2.1.5"
+      }
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
       }
     },
     "parse-asn1": {
@@ -2865,6 +3437,18 @@
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
     },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "dev": true
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -2875,6 +3459,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "promise-inflight": {
@@ -3012,6 +3602,12 @@
         "safe-regex": "^1.1.0"
       }
     },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -3092,6 +3688,16 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "requires": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -3117,6 +3723,12 @@
         "inherits": "^2.0.1"
       }
     },
+    "run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
+    },
     "run-queue": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
@@ -3124,6 +3736,15 @@
       "dev": true,
       "requires": {
         "aproba": "^1.1.1"
+      }
+    },
+    "rxjs": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
+      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -3140,6 +3761,12 @@
       "requires": {
         "ret": "~0.1.10"
       }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "schema-utils": {
       "version": "1.0.0",
@@ -3249,6 +3876,17 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -3415,6 +4053,12 @@
         "extend-shallow": "^3.0.0"
       }
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
     "ssri": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
@@ -3519,6 +4163,12 @@
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
+    "strip-json-comments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
+      "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
+      "dev": true
+    },
     "style-loader": {
       "version": "0.23.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.23.1.tgz",
@@ -3536,6 +4186,44 @@
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+          "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "tapable": {
@@ -3588,6 +4276,18 @@
         }
       }
     },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
     "through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
@@ -3605,6 +4305,15 @@
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
+      }
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-arraybuffer": {
@@ -3665,6 +4374,21 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
     },
     "typedarray": {
@@ -4098,6 +4822,12 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
     "worker-farm": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
@@ -4123,6 +4853,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "ws": {
       "version": "7.0.1",

--- a/js/package.json
+++ b/js/package.json
@@ -12,8 +12,14 @@
   "scripts": {
     "build": "webpack",
     "clean": "rimraf dist/",
+    "eslint": "eslint . --fix --ignore-path ../.gitignore",
+    "eslint:check": "eslint . --ignore-path ../.gitignore",
+    "lint": "npm run prettier && npm run eslint",
+    "lint:check": "npm run prettier:check && npm run eslint:check",
     "postinstall": "npm run build",
     "prepack": "npm run postinstall",
+    "prettier": "prettier --ignore-path ../.gitignore --write \"**/*{.ts,.tsx,.js,.jsx,.css,.json}\"",
+    "prettier:check": "prettier --check --ignore-path ../.gitignore \"**/*{.ts,.tsx,.js,.jsx,.css,.json}\"",
     "test": "echo \"Error: no test specified\" && exit 1",
     "watch": "webpack --watch"
   },
@@ -22,8 +28,11 @@
   },
   "devDependencies": {
     "css-loader": "^3.5.3",
+    "eslint": "^6.8.0",
+    "eslint-config-prettier": "^6.10.1",
     "fs-extra": "^4.0.2",
     "json-loader": "^0.5.4",
+    "prettier": "^2.0.2",
     "rimraf": "^2.6.1",
     "style-loader": "^0.23.1",
     "webpack": "^4.41.6",

--- a/js/src/lab_extension.js
+++ b/js/src/lab_extension.js
@@ -5,12 +5,12 @@ var base = require('@jupyter-widgets/base');
 module.exports = {
     id: 'matplotlib-jupyter:main',
     requires: [base.IJupyterWidgetRegistry],
-    activate: function(app, widgets) {
+    activate: function (app, widgets) {
         widgets.registerWidget({
             name: 'jupyter-matplotlib',
             version: jupyter_matplotlib.version,
-            exports: jupyter_matplotlib
+            exports: jupyter_matplotlib,
         });
     },
-    autoStart: true
+    autoStart: true,
 };

--- a/js/src/mpl_widget.js
+++ b/js/src/mpl_widget.js
@@ -161,7 +161,7 @@ class MPLCanvasModel extends widgets.DOMWidgetModel {
         });
     }
 
-    handle_draw(msg) {
+    handle_draw(_msg) {
         // Request the server to send over a new figure.
         this.send_draw_message();
     }
@@ -345,7 +345,7 @@ class MPLCanvasView extends widgets.DOMWidgetView {
         this.figure.appendChild(this.header);
     }
 
-    _update_figure_label(msg) {
+    _update_figure_label(_msg) {
         this.header.textContent = this.model.get('_figure_label');
     }
 
@@ -398,7 +398,7 @@ class MPLCanvasView extends widgets.DOMWidgetView {
         this.top_context.strokeStyle = 'rgba(0, 0, 0, 255)';
 
         // Disable right mouse context menu.
-        this.top_canvas.addEventListener('contextmenu', function(e) {
+        this.top_canvas.addEventListener('contextmenu', function(_e) {
             event.preventDefault();
             event.stopPropagation();
             return false;

--- a/js/src/mpl_widget.js
+++ b/js/src/mpl_widget.js
@@ -5,8 +5,7 @@ require('./mpl_widget.css');
 
 const version = require('../package.json').version;
 
-export
-class MPLCanvasModel extends widgets.DOMWidgetModel {
+export class MPLCanvasModel extends widgets.DOMWidgetModel {
     defaults() {
         return {
             ...super.defaults(),
@@ -14,7 +13,7 @@ class MPLCanvasModel extends widgets.DOMWidgetModel {
             _view_name: 'MPLCanvasView',
             _model_module: 'jupyter-matplotlib',
             _view_module: 'jupyter-matplotlib',
-            _model_module_version: '^'+ version,
+            _model_module_version: '^' + version,
             _view_module_version: '^' + version,
             header_visible: true,
             footer_visible: true,
@@ -40,11 +39,13 @@ class MPLCanvasModel extends widgets.DOMWidgetModel {
 
         this.offscreen_canvas = document.createElement('canvas');
         this.offscreen_context = this.offscreen_canvas.getContext('2d');
-        const backingStore = this.offscreen_context.backingStorePixelRatio ||
+        const backingStore =
+            this.offscreen_context.backingStorePixelRatio ||
             this.offscreen_context.webkitBackingStorePixelRatio ||
             this.offscreen_context.mozBackingStorePixelRatio ||
             this.offscreen_context.msBackingStorePixelRatio ||
-            this.offscreen_context.oBackingStorePixelRatio || 1;
+            this.offscreen_context.oBackingStorePixelRatio ||
+            1;
 
         this.requested_size = null;
         this.resize_requested = false;
@@ -53,9 +54,9 @@ class MPLCanvasModel extends widgets.DOMWidgetModel {
 
         this.on('msg:custom', this.on_comm_message.bind(this));
         this.on('change:resizable', () => {
-            this._for_each_view(function(view) {
+            this._for_each_view(function (view) {
                 view.update_canvas();
-            })
+            });
         });
 
         this.send_initialization_message();
@@ -69,7 +70,7 @@ class MPLCanvasModel extends widgets.DOMWidgetModel {
 
     send_initialization_message() {
         if (this.ratio != 1) {
-            this.send_message('set_dpi_ratio', {'dpi_ratio': this.ratio});
+            this.send_message('set_dpi_ratio', { dpi_ratio: this.ratio });
         }
 
         this.send_message('send_image_mode');
@@ -100,7 +101,7 @@ class MPLCanvasModel extends widgets.DOMWidgetModel {
         this.offscreen_context.drawImage(this.image, 0, 0);
 
         if (!this.resize_requested) {
-            this._for_each_view(function(view) {
+            this._for_each_view(function (view) {
                 view.resize_canvas(size[0], size[1]);
             });
         }
@@ -121,7 +122,7 @@ class MPLCanvasModel extends widgets.DOMWidgetModel {
             return;
         }
 
-        this._for_each_view(function(view) {
+        this._for_each_view(function (view) {
             // Do an initial resize of each view, stretching the old canvas.
             view.resize_canvas(width, height);
         });
@@ -131,7 +132,7 @@ class MPLCanvasModel extends widgets.DOMWidgetModel {
             this.requested_size = [width, height];
         } else {
             this.resize_requested = true;
-            this.send_message('resize', {'width': width, 'height': height});
+            this.send_message('resize', { width: width, height: height });
         }
     }
 
@@ -156,7 +157,7 @@ class MPLCanvasModel extends widgets.DOMWidgetModel {
         this.set('_rubberband_height', Math.abs(y1 - y0));
         this.save_changes();
 
-        this._for_each_view(function(view) {
+        this._for_each_view(function (view) {
             view.update_canvas();
         });
     }
@@ -170,7 +171,7 @@ class MPLCanvasModel extends widgets.DOMWidgetModel {
         const url_creator = window.URL || window.webkitURL;
 
         const buffer = new Uint8Array(dataviews[0].buffer);
-        const blob = new Blob([buffer], {type: 'image/png'});
+        const blob = new Blob([buffer], { type: 'image/png' });
         const image_url = url_creator.createObjectURL(blob);
 
         // Free the memory for the previous frames
@@ -196,7 +197,10 @@ class MPLCanvasModel extends widgets.DOMWidgetModel {
         try {
             callback = this['handle_' + msg_type].bind(this);
         } catch (e) {
-            console.log('No handler for the \'' + msg_type + '\' message type: ', msg);
+            console.log(
+                "No handler for the '" + msg_type + "' message type: ",
+                msg
+            );
             return;
         }
 
@@ -212,11 +216,16 @@ class MPLCanvasModel extends widgets.DOMWidgetModel {
                 // Full images could contain transparency (where diff images
                 // almost always do), so we need to clear the canvas so that
                 // there is no ghosting.
-                this.offscreen_context.clearRect(0, 0, this.offscreen_canvas.width, this.offscreen_canvas.height);
+                this.offscreen_context.clearRect(
+                    0,
+                    0,
+                    this.offscreen_canvas.width,
+                    this.offscreen_canvas.height
+                );
             }
             this.offscreen_context.drawImage(this.image, 0, 0);
 
-            this._for_each_view(function(view) {
+            this._for_each_view(function (view) {
                 view.update_canvas();
             });
         };
@@ -237,12 +246,10 @@ class MPLCanvasModel extends widgets.DOMWidgetModel {
 
 MPLCanvasModel.serializers = {
     ...widgets.DOMWidgetModel.serializers,
-    toolbar: { deserialize: widgets.unpack_models }
+    toolbar: { deserialize: widgets.unpack_models },
 };
 
-
-export
-class MPLCanvasView extends widgets.DOMWidgetView {
+export class MPLCanvasView extends widgets.DOMWidgetView {
     render() {
         this.canvas = undefined;
         this.context = undefined;
@@ -252,7 +259,8 @@ class MPLCanvasView extends widgets.DOMWidgetView {
         this.resize_handle_size = 20;
 
         this.figure = document.createElement('div');
-        this.figure.classList = 'jupyter-matplotlib-figure jupyter-widgets widget-container widget-box widget-vbox';
+        this.figure.classList =
+            'jupyter-matplotlib-figure jupyter-widgets widget-container widget-box widget-vbox';
 
         this._init_header();
         this._init_canvas();
@@ -265,45 +273,69 @@ class MPLCanvasView extends widgets.DOMWidgetView {
 
         this.waiting = false;
 
-        return this.create_child_view(this.model.get('toolbar')).then((toolbar_view) => {
-            this.toolbar_view = toolbar_view;
+        return this.create_child_view(this.model.get('toolbar')).then(
+            (toolbar_view) => {
+                this.toolbar_view = toolbar_view;
 
-            this._update_toolbar_position();
+                this._update_toolbar_position();
 
-            this._update_header_visible();
-            this._update_footer_visible();
-            this._update_toolbar_visible();
+                this._update_header_visible();
+                this._update_footer_visible();
+                this._update_toolbar_visible();
 
-            this.model_events();
-        });
+                this.model_events();
+            }
+        );
     }
 
     model_events() {
-        this.model.on('change:header_visible', this._update_header_visible.bind(this));
-        this.model.on('change:footer_visible', this._update_footer_visible.bind(this));
-        this.model.on('change:toolbar_visible', this._update_toolbar_visible.bind(this));
-        this.model.on('change:toolbar_position', this._update_toolbar_position.bind(this));
-        this.model.on('change:_figure_label', this._update_figure_label.bind(this));
+        this.model.on(
+            'change:header_visible',
+            this._update_header_visible.bind(this)
+        );
+        this.model.on(
+            'change:footer_visible',
+            this._update_footer_visible.bind(this)
+        );
+        this.model.on(
+            'change:toolbar_visible',
+            this._update_toolbar_visible.bind(this)
+        );
+        this.model.on(
+            'change:toolbar_position',
+            this._update_toolbar_position.bind(this)
+        );
+        this.model.on(
+            'change:_figure_label',
+            this._update_figure_label.bind(this)
+        );
         this.model.on('change:_message', this._update_message.bind(this));
         this.model.on('change:_cursor', this._update_cursor.bind(this));
     }
 
     _update_header_visible() {
-        this.header.style.display = this.model.get('header_visible') ? '': 'none';
+        this.header.style.display = this.model.get('header_visible')
+            ? ''
+            : 'none';
     }
 
     _update_footer_visible() {
-        this.footer.style.display = this.model.get('footer_visible') ? '': 'none';
+        this.footer.style.display = this.model.get('footer_visible')
+            ? ''
+            : 'none';
     }
 
     _update_toolbar_visible() {
-        this.toolbar_view.el.style.display = this.model.get('toolbar_visible') ? '' : 'none';
+        this.toolbar_view.el.style.display = this.model.get('toolbar_visible')
+            ? ''
+            : 'none';
     }
 
     _update_toolbar_position() {
         const toolbar_position = this.model.get('toolbar_position');
         if (toolbar_position == 'top' || toolbar_position == 'bottom') {
-            this.el.classList = 'jupyter-widgets widget-container widget-box widget-vbox jupyter-matplotlib';
+            this.el.classList =
+                'jupyter-widgets widget-container widget-box widget-vbox jupyter-matplotlib';
             this.model.get('toolbar').set('orientation', 'horizontal');
 
             this.clear();
@@ -316,7 +348,8 @@ class MPLCanvasView extends widgets.DOMWidgetView {
                 this.el.appendChild(this.toolbar_view.el);
             }
         } else {
-            this.el.classList = 'jupyter-widgets widget-container widget-box widget-hbox jupyter-matplotlib';
+            this.el.classList =
+                'jupyter-widgets widget-container widget-box widget-hbox jupyter-matplotlib';
             this.model.get('toolbar').set('orientation', 'vertical');
 
             this.clear();
@@ -351,10 +384,11 @@ class MPLCanvasView extends widgets.DOMWidgetView {
 
     _init_canvas() {
         const canvas_container = document.createElement('div');
-        canvas_container.classList = 'jupyter-widgets jupyter-matplotlib-canvas-container';
+        canvas_container.classList =
+            'jupyter-widgets jupyter-matplotlib-canvas-container';
         this.figure.appendChild(canvas_container);
 
-        const canvas_div = this.canvas_div = document.createElement('div');
+        const canvas_div = (this.canvas_div = document.createElement('div'));
         canvas_div.style.position = 'relative';
         canvas_div.style.clear = 'both';
         canvas_div.classList = 'jupyter-widgets jupyter-matplotlib-canvas-div';
@@ -366,7 +400,7 @@ class MPLCanvasView extends widgets.DOMWidgetView {
         canvas_div.setAttribute('tabindex', 0);
         canvas_container.appendChild(canvas_div);
 
-        const canvas = this.canvas = document.createElement('canvas');
+        const canvas = (this.canvas = document.createElement('canvas'));
         canvas.style.display = 'block';
         canvas.style.position = 'absolute';
         canvas.style.left = 0;
@@ -375,19 +409,34 @@ class MPLCanvasView extends widgets.DOMWidgetView {
 
         this.context = canvas.getContext('2d');
 
-        const top_canvas = this.top_canvas = document.createElement('canvas');
+        const top_canvas = (this.top_canvas = document.createElement('canvas'));
         top_canvas.style.display = 'block';
         top_canvas.style.position = 'absolute';
         top_canvas.style.left = 0;
         top_canvas.style.top = 0;
         top_canvas.style.zIndex = 1;
 
-        top_canvas.addEventListener('mousedown', this.mouse_event('button_press'));
-        top_canvas.addEventListener('mouseup', this.mouse_event('button_release'));
-        top_canvas.addEventListener('mousemove', this.mouse_event('motion_notify'));
+        top_canvas.addEventListener(
+            'mousedown',
+            this.mouse_event('button_press')
+        );
+        top_canvas.addEventListener(
+            'mouseup',
+            this.mouse_event('button_release')
+        );
+        top_canvas.addEventListener(
+            'mousemove',
+            this.mouse_event('motion_notify')
+        );
 
-        top_canvas.addEventListener('mouseenter', this.mouse_event('figure_enter'));
-        top_canvas.addEventListener('mouseleave', this.mouse_event('figure_leave'));
+        top_canvas.addEventListener(
+            'mouseenter',
+            this.mouse_event('figure_enter')
+        );
+        top_canvas.addEventListener(
+            'mouseleave',
+            this.mouse_event('figure_leave')
+        );
 
         top_canvas.addEventListener('wheel', this.mouse_event('scroll'));
 
@@ -398,7 +447,7 @@ class MPLCanvasView extends widgets.DOMWidgetView {
         this.top_context.strokeStyle = 'rgba(0, 0, 0, 255)';
 
         // Disable right mouse context menu.
-        this.top_canvas.addEventListener('contextmenu', function(_e) {
+        this.top_canvas.addEventListener('contextmenu', function (_e) {
             event.preventDefault();
             event.stopPropagation();
             return false;
@@ -416,13 +465,23 @@ class MPLCanvasView extends widgets.DOMWidgetView {
         this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
         this.context.drawImage(this.model.offscreen_canvas, 0, 0);
 
-        this.top_context.clearRect(0, 0, this.top_canvas.width, this.top_canvas.height);
+        this.top_context.clearRect(
+            0,
+            0,
+            this.top_canvas.width,
+            this.top_canvas.height
+        );
 
         // Draw rubberband
-        if (this.model.get('_rubberband_width') != 0 && this.model.get('_rubberband_height') != 0) {
+        if (
+            this.model.get('_rubberband_width') != 0 &&
+            this.model.get('_rubberband_height') != 0
+        ) {
             this.top_context.strokeRect(
-                this.model.get('_rubberband_x'), this.model.get('_rubberband_y'),
-                this.model.get('_rubberband_width'), this.model.get('_rubberband_height')
+                this.model.get('_rubberband_x'),
+                this.model.get('_rubberband_y'),
+                this.model.get('_rubberband_width'),
+                this.model.get('_rubberband_height')
             );
         }
 
@@ -431,8 +490,10 @@ class MPLCanvasView extends widgets.DOMWidgetView {
             this.top_context.save();
 
             var gradient = this.top_context.createLinearGradient(
-                this.top_canvas.width - this.resize_handle_size / 3, this.top_canvas.height - this.resize_handle_size / 3,
-                this.top_canvas.width - this.resize_handle_size / 4, this.top_canvas.height - this.resize_handle_size / 4
+                this.top_canvas.width - this.resize_handle_size / 3,
+                this.top_canvas.height - this.resize_handle_size / 3,
+                this.top_canvas.width - this.resize_handle_size / 4,
+                this.top_canvas.height - this.resize_handle_size / 4
             );
             gradient.addColorStop(0, 'rgba(0, 0, 0, 0)');
             gradient.addColorStop(1, 'rgba(0, 0, 0, 255)');
@@ -441,9 +502,18 @@ class MPLCanvasView extends widgets.DOMWidgetView {
 
             this.top_context.globalAlpha = 0.3;
             this.top_context.beginPath();
-            this.top_context.moveTo(this.top_canvas.width, this.top_canvas.height);
-            this.top_context.lineTo(this.top_canvas.width, this.top_canvas.height - this.resize_handle_size);
-            this.top_context.lineTo(this.top_canvas.width - this.resize_handle_size, this.top_canvas.height);
+            this.top_context.moveTo(
+                this.top_canvas.width,
+                this.top_canvas.height
+            );
+            this.top_context.lineTo(
+                this.top_canvas.width,
+                this.top_canvas.height - this.resize_handle_size
+            );
+            this.top_context.lineTo(
+                this.top_canvas.width - this.resize_handle_size,
+                this.top_canvas.height
+            );
             this.top_context.closePath();
             this.top_context.fill();
 
@@ -489,7 +559,7 @@ class MPLCanvasView extends widgets.DOMWidgetView {
             const canvas_pos = utils.get_mouse_position(event, this.top_canvas);
 
             if (name === 'scroll') {
-                event['data'] = 'scroll'
+                event['data'] = 'scroll';
                 if (event.deltaY < 0) {
                     event.step = 1;
                 } else {
@@ -499,9 +569,13 @@ class MPLCanvasView extends widgets.DOMWidgetView {
 
             if (name === 'button_press') {
                 // If clicking on the resize handle
-                if (canvas_pos.x >= this.top_canvas.width - this.resize_handle_size &&
-                        canvas_pos.y >= this.top_canvas.height - this.resize_handle_size &&
-                        this.model.get('resizable')) {
+                if (
+                    canvas_pos.x >=
+                        this.top_canvas.width - this.resize_handle_size &&
+                    canvas_pos.y >=
+                        this.top_canvas.height - this.resize_handle_size &&
+                    this.model.get('resizable')
+                ) {
                     this.resizing = true;
                     return;
                 } else {
@@ -517,8 +591,12 @@ class MPLCanvasView extends widgets.DOMWidgetView {
 
             if (name === 'motion_notify') {
                 // If the mouse is on the handle, change the cursor style
-                if (canvas_pos.x >= this.top_canvas.width - this.resize_handle_size &&
-                        canvas_pos.y >= this.top_canvas.height - this.resize_handle_size) {
+                if (
+                    canvas_pos.x >=
+                        this.top_canvas.width - this.resize_handle_size &&
+                    canvas_pos.y >=
+                        this.top_canvas.height - this.resize_handle_size
+                ) {
                     this.top_canvas.style.cursor = 'nw-resize';
                 } else {
                     this.top_canvas.style.cursor = this.model.get('_cursor');
@@ -533,9 +611,13 @@ class MPLCanvasView extends widgets.DOMWidgetView {
                 var x = canvas_pos.x * this.model.ratio;
                 var y = canvas_pos.y * this.model.ratio;
 
-                this.model.send_message(name, {x: x, y: y, button: event.button,
-                                        step: event.step,
-                                        guiEvent: utils.get_simple_keys(event)});
+                this.model.send_message(name, {
+                    x: x,
+                    y: y,
+                    button: event.button,
+                    step: event.step,
+                    guiEvent: utils.get_simple_keys(event),
+                });
             }
         };
     }
@@ -559,32 +641,39 @@ class MPLCanvasView extends widgets.DOMWidgetView {
 
             // Prevent repeat events
             if (name == 'key_press') {
-                if (event.which === this._key)
+                if (event.which === this._key) {
                     return;
-                else
+                } else {
                     this._key = event.which;
+                }
             }
             if (name == 'key_release') {
                 this._key = null;
             }
 
             var value = '';
-            if (event.ctrlKey && event.which != 17)
+            if (event.ctrlKey && event.which != 17) {
                 value += 'ctrl+';
-            if (event.altKey && event.which != 18)
+            }
+            if (event.altKey && event.which != 18) {
                 value += 'alt+';
-            if (event.shiftKey && event.which != 16)
+            }
+            if (event.shiftKey && event.which != 16) {
                 value += 'shift+';
+            }
 
             value += 'k';
             value += event.which.toString();
 
-            this.model.send_message(name, {key: value, guiEvent: utils.get_simple_keys(event)});
+            this.model.send_message(name, {
+                key: value,
+                guiEvent: utils.get_simple_keys(event),
+            });
             return false;
         };
     }
 
-    remove(){
+    remove() {
         window.removeEventListener('mousemove', this._resize_event);
         window.removeEventListener('mouseup', this._stop_resize_event);
     }

--- a/js/src/nb_extension.js
+++ b/js/src/nb_extension.js
@@ -1,14 +1,14 @@
 if (window.require) {
     window.require.config({
         map: {
-            "*" : {
-                "jupyter-matplotlib": "nbextensions/jupyter-matplotlib/index",
-            }
-        }
+            '*': {
+                'jupyter-matplotlib': 'nbextensions/jupyter-matplotlib/index',
+            },
+        },
     });
 }
 
 // Export the required load_ipython_extention
 module.exports = {
-    load_ipython_extension: function() {}
+    load_ipython_extension: function () {},
 };

--- a/js/src/nb_index.js
+++ b/js/src/nb_index.js
@@ -7,7 +7,9 @@
 // dynamically.
 /* global __webpack_public_path__:writable */
 /* exported __webpack_public_path__ */
-__webpack_public_path__ = document.querySelector('body').getAttribute('data-base-url') + 'nbextensions/jupyter-matplotlib/';
+__webpack_public_path__ =
+    document.querySelector('body').getAttribute('data-base-url') +
+    'nbextensions/jupyter-matplotlib/';
 
 // Export widget models and views, and the npm package version number.
 module.exports = require('./index.js');

--- a/js/src/nb_index.js
+++ b/js/src/nb_index.js
@@ -5,8 +5,9 @@
 // Some static assets may be required by the custom widget javascript. The base
 // url for the notebook is not known at build time and is therefore computed
 // dynamically.
+/* global __webpack_public_path__:writable */
+/* exported __webpack_public_path__ */
 __webpack_public_path__ = document.querySelector('body').getAttribute('data-base-url') + 'nbextensions/jupyter-matplotlib/';
 
 // Export widget models and views, and the npm package version number.
 module.exports = require('./index.js');
-

--- a/js/src/toolbar_widget.js
+++ b/js/src/toolbar_widget.js
@@ -98,7 +98,7 @@ class ToolbarView extends widgets.DOMWidgetView {
     }
 
     toolbar_button_onclick(name) {
-        return (event) => {
+        return (_event) => {
             // Special case for pan and zoom as they are toggle buttons
             if (name == 'pan' || name == 'zoom') {
                 if (this.model.get('_current_action') == name) {

--- a/js/src/toolbar_widget.js
+++ b/js/src/toolbar_widget.js
@@ -2,9 +2,7 @@ const widgets = require('@jupyter-widgets/base');
 
 const version = require('../package.json').version;
 
-
-export
-class ToolbarModel extends widgets.DOMWidgetModel {
+export class ToolbarModel extends widgets.DOMWidgetModel {
     defaults() {
         return {
             ...super.defaults(),
@@ -12,7 +10,7 @@ class ToolbarModel extends widgets.DOMWidgetModel {
             _view_name: 'ToolbarView',
             _model_module: 'jupyter-matplotlib',
             _view_module: 'jupyter-matplotlib',
-            _model_module_version: '^'+ version,
+            _model_module_version: '^' + version,
             _view_module_version: '^' + version,
             toolitems: [],
             orientation: 'vertical',
@@ -23,9 +21,7 @@ class ToolbarModel extends widgets.DOMWidgetModel {
     }
 }
 
-
-export
-class ToolbarView extends widgets.DOMWidgetView {
+export class ToolbarView extends widgets.DOMWidgetView {
     render() {
         this.el.classList = 'jupyter-widgets jupyter-matplotlib-toolbar';
         this.el.classList.add('widget-container', 'widget-box');
@@ -39,7 +35,8 @@ class ToolbarView extends widgets.DOMWidgetView {
 
         this.toggle_button = document.createElement('button');
 
-        this.toggle_button.classList = 'jupyter-matplotlib-button jupyter-widgets jupyter-button';
+        this.toggle_button.classList =
+            'jupyter-matplotlib-button jupyter-widgets jupyter-button';
         this.toggle_button.setAttribute('href', '#');
         this.toggle_button.setAttribute('title', 'Toggle Interaction');
         this.toggle_button.style.outline = 'none';
@@ -56,21 +53,27 @@ class ToolbarView extends widgets.DOMWidgetView {
         this.toolbar = document.createElement('div');
         this.toolbar.classList = 'widget-container widget-box';
         this.el.appendChild(this.toolbar);
-        this.buttons = {'toggle_button': this.toggle_button};
+        this.buttons = { toggle_button: this.toggle_button };
 
-        for(let toolbar_ind in toolbar_items) {
+        for (let toolbar_ind in toolbar_items) {
             const name = toolbar_items[toolbar_ind][0];
             const tooltip = toolbar_items[toolbar_ind][1];
             const image = toolbar_items[toolbar_ind][2];
             const method_name = toolbar_items[toolbar_ind][3];
-            if (!name) { continue; };
+            if (!name) {
+                continue;
+            }
 
             const button = document.createElement('button');
-            button.classList = 'jupyter-matplotlib-button jupyter-widgets jupyter-button';
+            button.classList =
+                'jupyter-matplotlib-button jupyter-widgets jupyter-button';
             button.setAttribute('href', '#');
             button.setAttribute('title', tooltip);
             button.style.outline = 'none';
-            button.addEventListener('click', this.toolbar_button_onclick(method_name));
+            button.addEventListener(
+                'click',
+                this.toolbar_button_onclick(method_name)
+            );
 
             const icon = document.createElement('i');
             icon.classList = 'center fa fa-' + image;
@@ -103,16 +106,15 @@ class ToolbarView extends widgets.DOMWidgetView {
             if (name == 'pan' || name == 'zoom') {
                 if (this.model.get('_current_action') == name) {
                     this.model.set('_current_action', '');
-                }
-                else {
+                } else {
                     this.model.set('_current_action', name);
                 }
                 this.model.save_changes();
             }
 
             this.send({
-                'type': 'toolbar_button',
-                'name': name
+                type: 'toolbar_button',
+                name: name,
             });
         };
     }
@@ -123,7 +125,7 @@ class ToolbarView extends widgets.DOMWidgetView {
             success: ['mod-success'],
             info: ['mod-info'],
             warning: ['mod-warning'],
-            danger: ['mod-danger']
+            danger: ['mod-danger'],
         };
 
         for (let name in this.buttons) {
@@ -151,7 +153,10 @@ class ToolbarView extends widgets.DOMWidgetView {
 
     model_events() {
         this.model.on('change:orientation', this.update_orientation.bind(this));
-        this.model.on_some_change(['button_style', '_current_action'], this.set_buttons_style.bind(this));
+        this.model.on_some_change(
+            ['button_style', '_current_action'],
+            this.set_buttons_style.bind(this)
+        );
         this.model.on('change:collapsed', this.update_collapsed.bind(this));
     }
 

--- a/js/src/utils.js
+++ b/js/src/utils.js
@@ -1,24 +1,23 @@
 // Get mouse position relative to target
-export
-function get_mouse_position(event, targ) {
+export function get_mouse_position(event, targ) {
     var boundingRect = targ.getBoundingClientRect();
 
     return {
         x: event.clientX - boundingRect.left,
-        y: event.clientY - boundingRect.top
+        y: event.clientY - boundingRect.top,
     };
-};
+}
 
 /*
  * return a copy of an object with only non-object keys
  * we need this to avoid circular references
  * http://stackoverflow.com/a/24161582/3208463
  */
-export
-function get_simple_keys(original) {
+export function get_simple_keys(original) {
     return Object.keys(original).reduce(function (obj, key) {
-        if (typeof original[key] !== 'object')
-            obj[key] = original[key]
+        if (typeof original[key] !== 'object') {
+            obj[key] = original[key];
+        }
         return obj;
     }, {});
 }

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -1,3 +1,4 @@
+/*eslint-env node*/
 var fs = require('fs-extra');
 var path = require('path');
 var version = require('./package.json').version;

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -5,76 +5,77 @@ var version = require('./package.json').version;
 
 // Custom webpack rules are generally the same for all webpack bundles, hence
 // stored in a separate local variable.
-var rules = [
-    { test: /\.css$/, use: ['style-loader', 'css-loader']}
-]
+var rules = [{ test: /\.css$/, use: ['style-loader', 'css-loader'] }];
 
 // The static file directory.
 var staticDir = path.resolve(__dirname, '..', 'ipympl', 'static');
 
-
 // Copy the package.json to static so we can inspect its version.
-fs.copySync('./package.json', path.join(staticDir, 'package.json'))
-
+fs.copySync('./package.json', path.join(staticDir, 'package.json'));
 
 module.exports = [
-    {// Notebook extension
-     //
-     // This bundle only contains the part of the JavaScript that is run on
-     // load of the notebook. This section generally only performs
-     // some configuration for requirejs, and provides the legacy
-     // "load_ipython_extension" function which is required for any notebook
-     // extension.
-     //
+    {
+        // Notebook extension
+        //
+        // This bundle only contains the part of the JavaScript that is run on
+        // load of the notebook. This section generally only performs some
+        // configuration for requirejs, and provides the legacy
+        // "load_ipython_extension" function which is required for any notebook
+        // extension.
+        //
         entry: './src/nb_extension.js',
         output: {
             filename: 'extension.js',
             path: staticDir,
-            libraryTarget: 'amd'
-        }
+            libraryTarget: 'amd',
+        },
     },
-    {// Bundle for the notebook containing the custom widget views and models
-     //
-     // This bundle contains the implementation for the custom widget views and
-     // models.
-     //
+    {
+        // Bundle for the notebook containing the custom widget views and
+        // models
+        //
+        // This bundle contains the implementation for the custom widget views
+        // and models.
+        //
         entry: './src/nb_index.js',
         output: {
             filename: 'index.js',
             path: staticDir,
-            libraryTarget: 'amd'
+            libraryTarget: 'amd',
         },
         devtool: 'source-map',
         module: {
-            rules: rules
+            rules: rules,
         },
-        externals: ['@jupyter-widgets/base']
+        externals: ['@jupyter-widgets/base'],
     },
-    {// Embeddable jupyter-matplotlib bundle
-     //
-     // This bundle is generally almost identical to the notebook bundle
-     // containing the custom widget views and models.
-     //
-     // The only difference is in the configuration of the webpack public path
-     // for the static assets.
-     //
-     // It will be automatically distributed by unpkg to work with the static
-     // widget embedder.
-     //
-     // The target bundle is always `dist/index.js`, which is the path required
-     // by the custom widget embedder.
-     //
+    {
+        // Embeddable jupyter-matplotlib bundle
+        //
+        // This bundle is generally almost identical to the notebook bundle
+        // containing the custom widget views and models.
+        //
+        // The only difference is in the configuration of the webpack public
+        // path for the static assets.
+        //
+        // It will be automatically distributed by unpkg to work with the
+        // static widget embedder.
+        //
+        // The target bundle is always `dist/index.js`, which is the path
+        // required by the custom widget embedder.
+        //
         entry: './src/index.js',
         output: {
             filename: 'index.js',
             path: path.resolve(__dirname, 'dist'),
             libraryTarget: 'amd',
-            publicPath: 'https://unpkg.com/jupyter-matplotlib@' + version + '/dist/'
+            publicPath:
+                'https://unpkg.com/jupyter-matplotlib@' + version + '/dist/',
         },
         devtool: 'source-map',
         module: {
-            rules: rules
+            rules: rules,
         },
-        externals: ['@jupyter-widgets/base']
-    }
+        externals: ['@jupyter-widgets/base'],
+    },
 ];


### PR DESCRIPTION
This pulls in the same lint/format method used for ipywidgets, though there are a few differences to minimize changes.
* TypeScript isn't used, so I left out any typescript lint config/plugins.
* Since you've used the spread operation, I've set ECMA version to 9, though it could be set to anything later if you wish.
* Prettier is set to use 4-space tab width for existing files (except `package*.json` which is already 2-space), or else I've have to rewrite basically everything.

Some other non-defaullt changes:
* I added braces on some `if` so they would stay separate lines.
* I added a ignore pattern for args that start with `_` so `eslint` wouldn't complain they were unused.

Having a common style is helpful for cross-project sharing, and I plan to apply the same change to Matplotlib's nbagg/webagg backends. However, I am not an expert in the JS ecosystem, so I may not have worked around any issues in the best way.

Adding the config and applying the format are separate commits for easier review.