### PR TITLE
Add option to preventDefault on scroll event

### DIFF
--- a/examples/ipympl.ipynb
+++ b/examples/ipympl.ipynb
@@ -71,6 +71,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "fig.canvas.capture_scroll = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "fig.canvas"
    ]
   },

--- a/ipympl/backend_nbagg.py
+++ b/ipympl/backend_nbagg.py
@@ -175,6 +175,7 @@ class Canvas(DOMWidget, FigureCanvasWebAggCore):
     footer_visible = Bool(True).tag(sync=True)
 
     resizable = Bool(True).tag(sync=True)
+    capture_scroll = Bool(False).tag(sync=True)
 
     _width = CInt().tag(sync=True)
     _height = CInt().tag(sync=True)

--- a/js/src/mpl_widget.js
+++ b/js/src/mpl_widget.js
@@ -21,6 +21,7 @@ export class MPLCanvasModel extends widgets.DOMWidgetModel {
             toolbar_visible: true,
             toolbar_position: 'horizontal',
             resizable: true,
+            capture_scroll: false,
             _width: 0,
             _height: 0,
             _figure_label: 'Figure',
@@ -564,6 +565,9 @@ export class MPLCanvasView extends widgets.DOMWidgetView {
                     event.step = 1;
                 } else {
                     event.step = -1;
+                }
+                if (this.model.get('capture_scroll')) {
+                    event.preventDefault();
                 }
             }
 


### PR DESCRIPTION
closes: https://github.com/matplotlib/ipympl/issues/222

Following the way `resizeable` was added I added `capture_scroll` to the canvas object with a default of `False`. If set to true then the entire notebook will not scroll when a user scrolls the mouse over a canvas. This allows the enduser to implement things such as custom scroll to zoom methods.