### PR TITLE
Update jlab dev install instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,5 +21,5 @@ python -c "import sys; print('\n',sys.version); import ipympl; print('ipympl ver
 ```
 -->
 ```
-Paste here the command output.
+Paste the command output here.
 ```

--- a/README.md
+++ b/README.md
@@ -93,8 +93,18 @@ jupyter nbextension enable --py --sys-prefix ipympl
 
 # If using JupyterLab
 jupyter labextension install @jupyter-widgets/jupyterlab-manager --no-build
-jupyter labextension link ./js
-cd js && npm run watch
-# Launch jupyterlab as `jupyter lab --watch` in another terminal
+jupyter labextension install ./js
 ```
 
+#### How to see your changes
+**Javascript**:
+
+To continuously monitor the project for changes and automatically trigger a rebuild, start Jupyter in watch mode:
+
+jupyter lab --watch
+
+After a change wait for the build to finish and then refresh your browser and the changes should take effect.
+
+**Python:**
+
+If you make a change to the python code then you will need to restart the notebook kernel to have it take effect.


### PR DESCRIPTION
- Use `install` instead of `link` ([ref](https://gitter.im/jupyterlab/jupyterlab?at=5ee6abf324a3382d5d68b2ae))
- add instructions for seeing your changes
- fixed incorrect grammar in the issue template