### PR TITLE
Fix hidden toolbar icons

### DIFF
--- a/js/src/mpl_widget.css
+++ b/js/src/mpl_widget.css
@@ -12,8 +12,7 @@
 
 .jupyter-matplotlib-button {
   width: calc(var(--jp-widgets-inline-width-tiny) / 2 - 2px);
-  overflow: hidden;
-  padding: 0;
+  padding: 0 !important;
 }
 
 /* Figure */

--- a/js/src/toolbar_widget.js
+++ b/js/src/toolbar_widget.js
@@ -46,7 +46,7 @@ export class ToolbarView extends widgets.DOMWidgetView {
         });
 
         const icon = document.createElement('i');
-        icon.classList = 'center fa fa-bars';
+        icon.classList = 'center fa fa-fw fa-bars';
         this.toggle_button.appendChild(icon);
 
         this.el.appendChild(this.toggle_button);
@@ -76,7 +76,7 @@ export class ToolbarView extends widgets.DOMWidgetView {
             );
 
             const icon = document.createElement('i');
-            icon.classList = 'center fa fa-' + image;
+            icon.classList = 'center fa fa-fw fa-' + image;
             button.appendChild(icon);
 
             this.buttons[method_name] = button;


### PR DESCRIPTION
**Please read comment below and #246 before merging!**

Fixes toolbar icon(s) which were not displaying correctly due to the button width being too small to fit - just 'home' for me though this might fix #238 (presumably depends on font rendering differences between browsers / OS).

- Add the `fa-fw` class to ensure all icons are the same fixed width
- Ensure `padding: 0` is applied as this wasn't taking precedence over the default styles
  - Alternative approach would be to remove both the `width` and `padding` styles, which also leaves enough space to fit the icons, and doesn't appear (much?) different visually
- Remove unnecessary `overflow: hidden`

Before:

![Home icon is missing](https://user-images.githubusercontent.com/4248177/87234897-6b0dcd00-c3cd-11ea-97e2-2e6b3a6a9854.png)

After:

![All icons appear correctly](https://user-images.githubusercontent.com/4248177/87234892-592c2a00-c3cd-11ea-85f8-b69cae2b02e8.png)
