### PR TITLE
add jupyter keywords to package.json

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -40,5 +40,11 @@
   },
   "dependencies": {
     "@jupyter-widgets/base": "^2 || ^3"
-  }
+  },
+  "keywords": [
+    "jupyter",
+    "jupyterlab",
+    "jupyterlab-extension",
+    "widgets"
+  ]
 }


### PR DESCRIPTION
This will make jupyter-matplotlib discoverable by the jupyterlab extension manager. Which I suppose will be a totally different situation come jupyterlab3. But I imagine there will still be users on jlab2 for awhile and this will be useful to them.

Fixes: https://github.com/matplotlib/ipympl/issues/108