### PR TITLE
remove unnecessary traitlets to fix savefig and display(fig) errors

### DIFF
--- a/ipympl/backend_nbagg.py
+++ b/ipympl/backend_nbagg.py
@@ -198,12 +198,6 @@ class Canvas(DOMWidget, FigureCanvasWebAggCore):
     _force_full = Bool()
     _current_image_mode = Unicode()
     _dpi_ratio = Float(1.0)
-    _is_idle_drawing = Bool()
-    _is_saving = Bool()
-    _button = Any()
-    _key = Any()
-    _lastx = Any()
-    _lasty = Any()
 
     def __init__(self, figure, *args, **kwargs):
         DOMWidget.__init__(self, *args, **kwargs)


### PR DESCRIPTION
fixes: https://github.com/matplotlib/ipympl/issues/252

I also preemptively removed several other attributes that aren't used by the `js` and so do not need to be traitlets.

I left `force_full`, `_current_image_mode` and `_dpi_ratio` as these have code of the js side that could use them, although currently all of the values for those are hardcoded in the js and the traitlets aren't used.

attn: @martinRenou @tacaswell 

Could a release be made after merging this?