### PR TITLE
README: Add note on npm dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ pip install ipympl
 
 ### Install the JupyterLab extension
 
-In order to install the JupyterLab extension `jupyter-matplotlib`, you will first need to install `nodejs`, you can install it with `conda` doing
+In order to install the JupyterLab extension `jupyter-matplotlib`, you will first need to install `nodejs` and `npm`.
+You can install both with `conda` doing
 
 ```bash
 conda install -c conda-forge nodejs


### PR DESCRIPTION
npm is a direct dependency of the jupyter-widgets/jupyterlab-manager.

While often installed by default when installing nodejs, this must not
always be the case (e.g. [nodejs](https://www.archlinux.org/packages/community/x86_64/nodejs/) package in Archlinux doesn't contain [npm](https://www.archlinux.org/packages/community/any/npm/)).

Thus, a note on npm being a dependency is added.