### PR TITLE
Add instruction to restart jupyterlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ jupyter labextension install @jupyter-widgets/jupyterlab-manager
 # If you already installed the @jupyter-widgets/jupyterlab-manager extension, you will still need to rebuild JupyterLab after you installed ipympl
 jupyter lab build
 ```
+Make sure to restart JupyterLab after installing the extension
 
 #### Install an old JupyterLab extension
 


### PR DESCRIPTION
All of those are because they did not restart JupyterLab
https://github.com/matplotlib/ipympl/issues/275
https://github.com/matplotlib/ipympl/issues/148
https://github.com/matplotlib/ipympl/issues/66
https://github.com/matplotlib/ipympl/issues/201

Happen to me also, might even make people go back to notebook