### PR TITLE
Add automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Publish Package
+
+on:
+  release:
+    types: [published]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install node
+      uses: actions/setup-node@v1
+      with:
+        node-version: '14.x'
+        registry-url: 'https://registry.npmjs.org'
+    - name: Install Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install packaging setuptools twine wheel
+    - name: Publish the Python package
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*
+    - name: Publish the NPM package
+      run: |
+        echo $PRE_RELEASE
+        if [[ $PRE_RELEASE == "true" ]]; then export TAG="next"; else export TAG="latest"; fi
+        npm publish --tag ${TAG} --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        PRE_RELEASE: ${{ github.event.release.prerelease }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,16 +20,17 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install packaging setuptools twine wheel
+        pip install twine wheel build
     - name: Publish the Python package
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build
         twine upload dist/*
     - name: Publish the NPM package
       run: |
+        cd js
         echo $PRE_RELEASE
         if [[ $PRE_RELEASE == "true" ]]; then export TAG="next"; else export TAG="latest"; fi
         npm publish --tag ${TAG} --access public


### PR DESCRIPTION
This would allow the building of the wheel and the uploads to pypi and NPM to happen automatically on making a new release on github.

If this gets merged then someone with rights to publish to those platforms will need to generate an API key and add it to this repos secrets.

again @martinRenou  (sorry for sudden spam :/) but i'm hoping this one can make your life a bit easier when releasing :)