### PR TITLE
Fix plt.pause() behaviour

### DIFF
--- a/ipympl/backend_nbagg.py
+++ b/ipympl/backend_nbagg.py
@@ -242,12 +242,6 @@ class Canvas(DOMWidget, FigureCanvasWebAggCore):
     def new_timer(self, *args, **kwargs):
         return TimerTornado(*args, **kwargs)
 
-    def start_event_loop(self, timeout):
-        FigureCanvasBase.start_event_loop_default(self, timeout)
-
-    def stop_event_loop(self):
-        FigureCanvasBase.stop_event_loop_default(self)
-
 
 class FigureManager(FigureManagerWebAgg):
     ToolbarCls = Toolbar

--- a/ipympl/backend_nbagg.py
+++ b/ipympl/backend_nbagg.py
@@ -19,8 +19,7 @@ from matplotlib.backends.backend_webagg_core import (FigureManagerWebAgg,
                                                      FigureCanvasWebAggCore,
                                                      NavigationToolbar2WebAgg,
                                                      TimerTornado)
-from matplotlib.backend_bases import (ShowBase, NavigationToolbar2,
-                                      FigureCanvasBase, cursors)
+from matplotlib.backend_bases import ShowBase, NavigationToolbar2, cursors
 
 from ._version import js_semver
 


### PR DESCRIPTION
In #79, it is shown that plt.pause() raises an error when using ipympl.
```python
%matplotlib widget
import matplotlib.pyplot as plt
fig = plt.figure()
plt.plot([1,2,3]) # this line isn't necessary
plt.pause(1)    
# AttributeError
```

In that issue, there is discussion recommending removing the two methods that raise the error, as the `FigureCanvasBase.start_event_loop_default` method does not exist. This PR implements that.

It turns out that the ipympl Canvas object actually inherits from `FigureCanvasBase` anyway (through `Canvas` -> `FigureCanvasWebAggCore` -> `backend_agg.FigureCanvasAgg` -> `FigureCanvasBase`), so removing them or renaming the called methods to remove the `_default` are equivalent.

Here is a gif showing the new behaviour with this PR (previous was an error)

<img src="https://user-images.githubusercontent.com/2721423/103767668-57ac8900-5021-11eb-8a37-8522d6624845.gif" width="300px" alt="Working plt.pause()">

