### PR TITLE
Install ipympl from conda

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -6,4 +6,4 @@ dependencies:
   - numpy
   - jupyterlab>=3
   - matplotlib-base>=2.2.2
-  - jupyter-packaging=0.7
+  - ipympl=0.8

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-python -m pip install -vvv -e .
-jupyter labextension develop . --overwrite


### PR DESCRIPTION
Adopting the same patter of reseting `stable` on `master` when the new version of the conda package is available.

cc @martinRenou 