### PR TITLE
Guard against ipympl.backend_nbagg being imported outside of an IPython context

### DIFF
--- a/ipympl/backend_nbagg.py
+++ b/ipympl/backend_nbagg.py
@@ -428,4 +428,5 @@ def flush_figures():
 
 
 ip = get_ipython()
-ip.events.register('post_execute', flush_figures)
+if ip is not None:
+    ip.events.register('post_execute', flush_figures)


### PR DESCRIPTION
Closes https://github.com/matplotlib/ipympl/issues/363


```
$ python -c "import ipympl.backend_nbagg"; echo $?
0
```