### PR TITLE
slow down pre-commit autoupdates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+ci:
+  autoupdate_schedule: 'quarterly'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1


### PR DESCRIPTION
The default is `weekly` which I don't think is really necessary and introduces a decent amount of PR noise.