### PR TITLE
Fix nbconvert pdf export

### DIFF
--- a/ipympl/backend_nbagg.py
+++ b/ipympl/backend_nbagg.py
@@ -327,6 +327,7 @@ class Canvas(DOMWidget, FigureCanvasWebAggCore):
 
         data = {
             'text/plain': plaintext,
+            'image/png': self._data_url,
             'text/html': html,
             'application/vnd.jupyter.widget-view+json': {
                 'version_major': 2,


### PR DESCRIPTION
Fix #403 

When exporting to pdf, the only mimetype that makes sense is the `image/png` one, so we need it around.