### PR TITLE
allow  ipython-8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup_args = dict(
     license='BSD License',
     include_package_data=True,
     install_requires=[
-        'ipython<8',
+        'ipython<9',
         'numpy',
         'ipython_genutils',
         'pillow',


### PR DESCRIPTION
now that ipython-8 is there, maybe it's not a problem https://github.com/matplotlib/ipympl/issues/409