### PR TITLE
button for canvas toolbar which enables creating a pdf of the figure

### DIFF
--- a/ipympl/backend_nbagg.py
+++ b/ipympl/backend_nbagg.py
@@ -147,11 +147,13 @@ class Toolbar(DOMWidget, NavigationToolbar2WebAgg):
             'move': 'arrows',
             'download': 'floppy-o',
             'export': 'file-picture-o',
+            'make_pdf': 'file-pdf'
         }
 
         download_item = ('Download', 'Download plot', 'download', 'save_figure')
+        make_pdf = ('Create pdf', 'Create pdf from figure', 'make_pdf', 'makepdf')
 
-        toolitems = NavigationToolbar2.toolitems + (download_item,)
+        toolitems = NavigationToolbar2.toolitems + (download_item,) + (make_pdf,)
 
         return [
             (text, tooltip, icons[icon_name], method_name)
@@ -274,6 +276,9 @@ class Canvas(DOMWidget, FigureCanvasWebAggCore):
         elif content['type'] == 'set_dpi_ratio':
             Canvas.current_dpi_ratio = content['dpi_ratio']
             self.manager.handle_json(content)
+
+        elif content['type'] == 'toolbar_button' and content['name'] == 'makepdf':
+            self._send_savefig_pdf()
 
         else:
             self.manager.handle_json(content)
@@ -450,6 +455,10 @@ class Canvas(DOMWidget, FigureCanvasWebAggCore):
 
         handle_key_press = handle_key_release = _handle_key
 
+    def _send_savefig_pdf(self):
+        buf = io.BytesIO()
+        self.figure.savefig(buf, format='pdf', dpi='figure')
+        self.send({'data': '{"type": "makepdf"}'}, buffers=[buf.getbuffer()])
 
 class FigureManager(FigureManagerWebAgg):
     if matplotlib.__version__ < "3.6":

--- a/src/mpl_widget.ts
+++ b/src/mpl_widget.ts
@@ -157,6 +157,14 @@ export class MPLCanvasModel extends DOMWidgetModel {
         document.body.removeChild(save);
     }
 
+    handle_makepdf(msg: any, dataviews: any) {
+        const url_creator = window.URL || window.webkitURL;
+        const buffer = new Uint8Array(dataviews[0].buffer);
+        const blob = new Blob([buffer], { type: 'application/pdf' });
+        const image_url = url_creator.createObjectURL(blob);
+        window.open(image_url, '_blank');
+    }
+
     handle_resize(msg: { [index: string]: any }) {
         this.resize_canvas();
         this.offscreen_context.drawImage(this.image, 0, 0);


### PR DESCRIPTION
As discussed with @ianhi, this is an attempt to (partially) address #138. 
This would add an additional button to the toolbar associated with a `figure.canvas`. Once clicked, a pdf is generated with `savefig` and then handed over to the frontend inside a new tab. 

![image](https://user-images.githubusercontent.com/19193849/160305885-85e8a9ad-e7bb-471d-a317-81cc014a5920.png)

