### PR TITLE
fixed `example notebook` filepath

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ magic:
 ```
 
 ## Example
-See the [example notebook](https://github.com/matplotlib/ipympl/blob/master/docs/examples/ipympl.ipynb) for more!
+See the [example notebook](https://github.com/matplotlib/ipympl/blob/master/docs/examples/full-example.ipynb) for more!
 
 ![matplotlib screencast](matplotlib.gif)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ magic:
 ```
 
 ## Example
-See the [example notebook](https://github.com/matplotlib/ipympl/blob/master/docs/examples/full-example.ipynb) for more!
+See the [example notebook](https://github.com/matplotlib/ipympl/blob/main/docs/examples/full-example.ipynb) for more!
 
 ![matplotlib screencast](matplotlib.gif)
 


### PR DESCRIPTION
Minor typo fixed.  Changed the missing link from `ipympl.ipynb` to `full-example.ipynb`.