### PR TITLE
support double click events

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
         "ts-jest": "^26.0.0",
         "ts-loader": "^8.0.0",
         "typescript": "~4.1.3",
-        "webpack": "^5.0.0",
+        "webpack": "^5.61.0",
         "webpack-cli": "^4.0.0"
     },
     "dependencies": {

--- a/src/mpl_widget.ts
+++ b/src/mpl_widget.ts
@@ -509,6 +509,7 @@ export class MPLCanvasView extends DOMWidgetView {
         top_canvas.style.top = '0';
         top_canvas.style.zIndex = '1';
 
+        top_canvas.addEventListener('dblclick', this.mouse_event('dblclick'));
         top_canvas.addEventListener(
             'mousedown',
             this.mouse_event('button_press')


### PR DESCRIPTION
closes: #261  attn @nvaytet


@martinRenou for version numbers what do we do here? I think we need to bump package.json 
https://github.com/matplotlib/ipympl/blob/21a1c8dde81e5732606c41054285ab2def9dba9f/package.json#L3

to either `0.11.0` or `0.10.6` and also bump the python version. Is there anything we can do here to ameliorate the patch version incompatibility (#416)?