### PR TITLE
Add model version separate from package version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/asottile/pyupgrade

--- a/ipympl/_version.py
+++ b/ipympl/_version.py
@@ -1,3 +1,9 @@
 version_info = (0, 8, 8)
 __version__ = '.'.join(map(str, version_info))
-js_semver = '^0.10.5'
+
+
+# The versions of protocol of communication with the frontend that this python verison knows
+# how to speak. See counterpart in the src/version.ts file.
+# These should not be changed unless we introduce changes to communication between
+# frontend and backend.
+__MODEL_VERSION__ = "1.0.0"

--- a/ipympl/backend_nbagg.py
+++ b/ipympl/backend_nbagg.py
@@ -58,7 +58,7 @@ from traitlets import (
     observe,
 )
 
-from ._version import js_semver
+from ._version import __MODEL_VERSION__
 
 cursors_str = {
     cursors.HAND: 'pointer',
@@ -93,11 +93,11 @@ def connection_info():
 class Toolbar(DOMWidget, NavigationToolbar2WebAgg):
 
     _model_module = Unicode('jupyter-matplotlib').tag(sync=True)
-    _model_module_version = Unicode(js_semver).tag(sync=True)
+    _model_module_version = Unicode(__MODEL_VERSION__).tag(sync=True)
     _model_name = Unicode('ToolbarModel').tag(sync=True)
 
     _view_module = Unicode('jupyter-matplotlib').tag(sync=True)
-    _view_module_version = Unicode(js_semver).tag(sync=True)
+    _view_module_version = Unicode(__MODEL_VERSION__).tag(sync=True)
     _view_name = Unicode('ToolbarView').tag(sync=True)
 
     toolitems = List().tag(sync=True)
@@ -180,11 +180,11 @@ class Toolbar(DOMWidget, NavigationToolbar2WebAgg):
 class Canvas(DOMWidget, FigureCanvasWebAggCore):
 
     _model_module = Unicode('jupyter-matplotlib').tag(sync=True)
-    _model_module_version = Unicode(js_semver).tag(sync=True)
+    _model_module_version = Unicode(__MODEL_VERSION__).tag(sync=True)
     _model_name = Unicode('MPLCanvasModel').tag(sync=True)
 
     _view_module = Unicode('jupyter-matplotlib').tag(sync=True)
-    _view_module_version = Unicode(js_semver).tag(sync=True)
+    _view_module_version = Unicode(__MODEL_VERSION__).tag(sync=True)
     _view_name = Unicode('MPLCanvasView').tag(sync=True)
 
     toolbar = Instance(Toolbar, allow_none=True).tag(sync=True, **widget_serialization)

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup_args = dict(
         'pillow',
         'traitlets<6',
         'ipywidgets>=7.6.0,<8',
-        'matplotlib>=2.0.0,<4',
+        'matplotlib>=3.4.0,<4',
     ],
     extras_require={
         "docs": [

--- a/src/mpl_widget.ts
+++ b/src/mpl_widget.ts
@@ -10,7 +10,7 @@ import {
 
 import * as utils from './utils';
 
-import { MODULE_VERSION } from './version';
+import { MODEL_VERSION } from './version';
 
 import { ToolbarView } from './toolbar_widget';
 
@@ -30,8 +30,8 @@ export class MPLCanvasModel extends DOMWidgetModel {
             _view_name: 'MPLCanvasView',
             _model_module: 'jupyter-matplotlib',
             _view_module: 'jupyter-matplotlib',
-            _model_module_version: '^' + MODULE_VERSION,
-            _view_module_version: '^' + MODULE_VERSION,
+            _model_module_version: MODEL_VERSION,
+            _view_module_version: MODEL_VERSION,
             header_visible: true,
             footer_visible: true,
             toolbar: null,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -4,7 +4,7 @@ import { Widget } from '@phosphor/widgets';
 
 import { IJupyterWidgetRegistry } from '@jupyter-widgets/base';
 
-import { MODULE_NAME, MODULE_VERSION } from './version';
+import { MODEL_VERSION, MODULE_NAME } from './version';
 
 const EXTENSION_ID = 'matplotlib-jupyter:main';
 
@@ -31,7 +31,7 @@ function activateWidgetExtension(
 ): void {
     registry.registerWidget({
         name: MODULE_NAME,
-        version: MODULE_VERSION,
-        exports: () => import('./index'),
+        version: MODEL_VERSION,
+        exports: (): any => import('./index'),
     });
 }

--- a/src/toolbar_widget.ts
+++ b/src/toolbar_widget.ts
@@ -1,6 +1,6 @@
 import { DOMWidgetModel, DOMWidgetView } from '@jupyter-widgets/base';
 
-import { MODULE_VERSION } from './version';
+import { MODEL_VERSION } from './version';
 
 import '../css/mpl_widget.css';
 
@@ -12,8 +12,8 @@ export class ToolbarModel extends DOMWidgetModel {
             _view_name: 'ToolbarView',
             _model_module: 'jupyter-matplotlib',
             _view_module: 'jupyter-matplotlib',
-            _model_module_version: '^' + MODULE_VERSION,
-            _view_module_version: '^' + MODULE_VERSION,
+            _model_module_version: MODEL_VERSION,
+            _view_module_version: MODEL_VERSION,
             toolitems: [],
             position: 'left',
             button_style: '',

--- a/src/version.ts
+++ b/src/version.ts
@@ -6,10 +6,19 @@ const data = require('../package.json');
  *
  * The html widget manager assumes that this is the same as the npm package
  * version number.
+ *
+ * See counterparts in the _version.py file
+ * These should not be changed unless we introduce changes to communication between
+ * frontend and backend.
  */
-export const MODULE_VERSION = data.version;
+export const MODEL_VERSION = '1.0.0';
 
 /*
  * The current package name.
  */
 export const MODULE_NAME = data.name;
+
+/*
+ * The package version
+ */
+export const MODULE_VERSION = data.version;


### PR DESCRIPTION
Hopefully fixes #416 

1. Adds a model version version that is not tied to the npm release version so that we can (hopefully) have compatibility across patch versions.

2. Bumps the version for release of the double click fixes