### PR TITLE
Remove unused 'close' arg to show().

### DIFF
--- a/ipympl/backend_nbagg.py
+++ b/ipympl/backend_nbagg.py
@@ -498,7 +498,7 @@ class _Backend_ipympl(_Backend):
         return manager
 
     @staticmethod
-    def show(close=None, block=None):
+    def show(block=None):
         # # TODO: something to do when keyword block==False ?
         interactive = is_interactive()
 


### PR DESCRIPTION
For reference, _Backend_ipympl.show is effectively the function that
pyplot.show calls (pyplot.show even copies the signature of the backend
show).

In af699c2, a 'close' kwarg was added to _Backend_ipympl.show, although
any use of it was immediately removed in a subsequent commit (783419b).
Still, this change means that calling e.g. `plt.show(True)`, for
example, would no longer set `block=True`, but instead set `close=True`.
As the change is relatively recent, it seems better to remove the unused
'close' kwarg again, which also makes the signature consistent with the
builtin Matplotlib backends.