### PR TITLE
Make handle_binary compliant with the KernelMessage.IMessage spec

### DIFF
--- a/src/mpl_widget.ts
+++ b/src/mpl_widget.ts
@@ -234,10 +234,10 @@ export class MPLCanvasModel extends DOMWidgetModel {
         this.send_draw_message();
     }
 
-    handle_binary(msg: any, dataviews: any) {
+    handle_binary(msg: any, buffers: (ArrayBuffer | ArrayBufferView)[]) {
         const url_creator = window.URL || window.webkitURL;
 
-        const buffer = new Uint8Array(dataviews[0].buffer);
+        const buffer = new Uint8Array(ArrayBuffer.isView(buffers[0]) ? buffers[0].buffer : buffers[0]);
         const blob = new Blob([buffer], { type: 'image/png' });
         const image_url = url_creator.createObjectURL(blob);
 
@@ -263,7 +263,7 @@ export class MPLCanvasModel extends DOMWidgetModel {
         // button to toggle?
     }
 
-    on_comm_message(evt: any, dataviews: any) {
+    on_comm_message(evt: any, buffers: (ArrayBuffer | ArrayBufferView)[]) {
         const msg = JSON.parse(evt.data);
         const msg_type = msg['type'];
         let callback;
@@ -281,7 +281,7 @@ export class MPLCanvasModel extends DOMWidgetModel {
         }
 
         if (callback) {
-            callback(msg, dataviews);
+            callback(msg, buffers);
         }
     }
 

--- a/src/mpl_widget.ts
+++ b/src/mpl_widget.ts
@@ -237,7 +237,9 @@ export class MPLCanvasModel extends DOMWidgetModel {
     handle_binary(msg: any, buffers: (ArrayBuffer | ArrayBufferView)[]) {
         const url_creator = window.URL || window.webkitURL;
 
-        const buffer = new Uint8Array(ArrayBuffer.isView(buffers[0]) ? buffers[0].buffer : buffers[0]);
+        const buffer = new Uint8Array(
+            ArrayBuffer.isView(buffers[0]) ? buffers[0].buffer : buffers[0]
+        );
         const blob = new Blob([buffer], { type: 'image/png' });
         const image_url = url_creator.createObjectURL(blob);
 


### PR DESCRIPTION
I found that `ipympl` was failing to display plots on more recent versions of the Jupyterlab 4.0 prereleases. This pull request fixes an issue where the  `handle_binary` expects a `DataView` but new versions of Jupyterlab will pass it an `ArrayBuffer`.

Since Jupyterlab v4.0.0a21 the buffers deserialized from a `KernelMessage` are now of type `ArrayBuffer` instead of the `DataView` type `handle_binary` expects. However, it turns out that the spec for `KernelMessage.IMessage` has always specified that buffers could be either an `ArrayBuffer` or an `ArrayBufferView`. This commit ensures either type is accepted.