### PR TITLE
Fix typo in "full-example.ipynb"

### DIFF
--- a/docs/examples/full-example.ipynb
+++ b/docs/examples/full-example.ipynb
@@ -107,7 +107,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can also call `display` on `fig.canvas` to display the interactive plot anywhere in the notebooke"
+    "You can also call `display` on `fig.canvas` to display the interactive plot anywhere in the notebook"
    ]
   },
   {


### PR DESCRIPTION
This PR aims to fix a typo in the Jupyter notebook `full-example.ipynb`.