### PR TITLE
Add matplotlib.backend entry points

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,12 +8,12 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 7.0.0
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-typing-imports==1.7.0]
+        additional_dependencies: [flake8-typing-imports==1.15.0]
   - repo: https://github.com/myint/autoflake
-    rev: v1.4
+    rev: v2.3.0
     hooks:
       - id: autoflake
         args: ["--in-place", "--remove-all-unused-imports", "--ignore-init-module-imports", "--remove-unused-variables"]

--- a/ipympl/backend_nbagg.py
+++ b/ipympl/backend_nbagg.py
@@ -540,7 +540,8 @@ class _Backend_ipympl(_Backend):
 
 
 def flush_figures():
-    if rcParams['backend'] == 'module://ipympl.backend_nbagg':
+    backend = matplotlib.get_backend()
+    if backend in ('widget', 'ipympl', 'module://ipympl.backend_nbagg'):
         if not _Backend_ipympl._draw_called:
             return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "traitlets<6",
 ]
 requires-python = ">=3.9"
-version = "0.9.3"
+version = "0.9.4.dev1"
 
 [project.optional-dependencies]
 docs = [
@@ -65,6 +65,10 @@ docs = [
 [project.urls]
 Homepage = "http://matplotlib.org/ipympl"
 Repository = "https://github.com/matplotlib/ipympl"
+
+[project.entry-points."matplotlib.backend"]
+ipympl = "ipympl.backend_nbagg"
+widget = "ipympl.backend_nbagg"
 
 [tool.hatch.build]
 artifacts = [

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -1,0 +1,11 @@
+def test_own_entry_points():
+    from importlib.metadata import entry_points
+
+    entries = entry_points(group="matplotlib.backend")
+    for name in ["ipympl", "widget"]:
+        assert name in entries.names
+        entry = entries[name]
+        assert entry.name == name
+        assert entry.value == "ipympl.backend_nbagg"
+        # Check can load module.
+        entry.load()

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -1,5 +1,5 @@
 def test_own_entry_points():
-    from importlib.metadata import entry_points
+    from importlib_metadata import entry_points
 
     entries = entry_points(group="matplotlib.backend")
     for name in ["ipympl", "widget"]:


### PR DESCRIPTION
This adds entry points to `pyproject.toml` for ipympl to register itself as a Matplotlib backend using the names  "widget" and "ipympl". It is part of the planned transition of backend mapping from IPython to Matplotlib (https://github.com/matplotlib/matplotlib/issues/27663 and https://github.com/ipython/ipython/issues/14311).

I have bumped the package __version__ as it will be used by Matplotlib to determine if a backward-compatible shim is required for this backend. I have also bumped some of the `pre-commit` hook versions which was required for `flake` to be happy on my dev machine.