### PR TITLE
Use correct versioning

### DIFF
--- a/ipympl/_version.py
+++ b/ipympl/_version.py
@@ -1,3 +1,3 @@
-version_info = (0, 9, 3)
+version_info = (0, 9, 4, "dev", 1)
 __version__ = '.'.join(map(str, version_info))
 js_semver = '^0.11'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,9 @@ dependencies = [
     "traitlets<6",
 ]
 requires-python = ">=3.9"
-version = "0.9.4.dev1"
+dynamic = [
+    "version",
+]
 
 [project.optional-dependencies]
 docs = [
@@ -105,6 +107,10 @@ npm = ["jlpm"]
 
 [tool.hatch.build.hooks.jupyter-builder.editable-build-kwargs]
 npm = ["jlpm"]
+
+[tool.hatch.version]
+path = "ipympl/_version.py"
+source = "code"
 
 [tool.pytest.ini_options]
 testpaths = [


### PR DESCRIPTION
When I updated the build system to use `hatch` (#541) I didn't set up the dynamic versioning correctly. This came to light in #549 as currently the package version is `0.9.4.dev1` but `ipympl.__version__` is still `0.9.3`.

This fixes the dynamic versioning in `pyproject.toml` so that `hatch` reads the one-and-only version number from `ipympl._version.py`.