### PR TITLE
Remove unnecessary dependency `ipython_genutils`

### DIFF
--- a/ipympl/backend_nbagg.py
+++ b/ipympl/backend_nbagg.py
@@ -31,7 +31,6 @@ import numpy as np
 from IPython import get_ipython
 from IPython import version_info as ipython_version_info
 from IPython.display import HTML, display
-from ipython_genutils.py3compat import string_types
 from ipywidgets import DOMWidget, widget_serialization
 from matplotlib import is_interactive, rcParams
 from matplotlib._pylab_helpers import Gcf
@@ -248,7 +247,7 @@ class Canvas(DOMWidget, FigureCanvasWebAggCore):
     def send_state(self, key=None):
         if key is None:
             keys = self.keys
-        elif isinstance(key, string_types):
+        elif isinstance(key, str):
             keys = [key]
         elif isinstance(key, Iterable):
             keys = key

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ classifiers = [
 ]
 dependencies = [
     "ipython<9",
-    "ipython_genutils",
     "ipywidgets>=7.6.0,<9",
     "matplotlib>=3.4.0,<4",
     "numpy",


### PR DESCRIPTION
I noticed this project depends on `ipython_genutils`, which was last updated in 2017.
Moreover, the only used thing from `ipython_genutils` was `ipython_genutils.py3compat.string_types`, which happens to be the tuple `(str,)`.

```python
from ipython_genutils.py3compat import string_types
assert string_types == (str,)  # ✅
assert string_types[0] is str  # ✅
```

Also removed a redundant python 2 check.