### PR TITLE
Include event.buttons in mouse events

### DIFF
--- a/src/mpl_widget.ts
+++ b/src/mpl_widget.ts
@@ -758,6 +758,7 @@ export class MPLCanvasView extends DOMWidgetView {
                 x: x,
                 y: y,
                 button: event.button,
+                buttons: event.buttons,
                 step: event.step,
                 modifiers: utils.getModifiers(event),
                 guiEvent: utils.get_simple_keys(event),


### PR DESCRIPTION
Fixes #567.

Matplotlib PR matplotlib/matplotlib#28453 added the use of `event.buttons` in mouse event messages that are handled by backends. We need to support the same here, otherwise `ipympl` does not work interactively with `matplotlib >= 3.10`.

It is a simple one-line fix, the same as at
https://github.com/matplotlib/matplotlib/blob/0400863b7a0d660d9333242fabd83dbfe3496503/lib/matplotlib/backends/web_backend/js/mpl.js#L647
It works for both matplotlib 3.10 and <3.10, as with the latter the new argument is just ignored.