### PR TITLE
Support python 3.13 in classifiers and CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        python: ['3.9', '3.12']
+        python: ['3.9', '3.13']
         mpl-version: ['latest']
         dist: ['ipympl*.whl']
         include:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Multimedia :: Graphics",
 ]
 dependencies = [


### PR DESCRIPTION
`ipympl` is working fine for me locally using python 3.13, so here adding a CI run for it on both `macos` and `ubuntu`, and updating the classifiers.