### PR TITLE
Use mpl.__version_info__ in FigureManager

### DIFF
--- a/ipympl/backend_nbagg.py
+++ b/ipympl/backend_nbagg.py
@@ -386,7 +386,7 @@ class Canvas(DOMWidget, FigureCanvasWebAggCore):
 
 
 class FigureManager(FigureManagerWebAgg):
-    if matplotlib.__version__ < "3.6":
+    if matplotlib.__version_info__ < (3, 6):
         ToolbarCls = Toolbar
 
     def __init__(self, canvas, num):


### PR DESCRIPTION
Change another use of `matplotlib.__version__` so that it is `matplotlib.__version_info__` to work correctly with matplotlib >= 3.10. See https://github.com/matplotlib/ipympl/pull/577#discussion_r1900878094.