### PR TITLE
Make 'Usage' section in README consistent with current Basic Example at current documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To enable the `ipympl` backend, simply use the `matplotlib` Jupyter
 magic:
 
 ```
-%matplotlib widget
+%matplotlib ipympl
 ```
 ## Documentation
 See the documentation at: https://matplotlib.org/ipympl/


### PR DESCRIPTION
The current Basic Example in the documentation [here](https://matplotlib.org/ipympl/#basic-example) uses:

```python
%matplotlib ipympl
```

This is nice/explicit and emphasizes you need `ipympl` installed. The documentation [there](https://matplotlib.org/ipympl/#basic-example) further reads, 'Alternatively you can use `%matplotlib widget` which will have the same effect.' This is good because lets legacy users know they can still use `%matplotlib widget`.

However, the current README at [the ipympl Github repo](https://github.com/matplotlib/ipympl) suggest usage [here in 'Usage' section](https://github.com/matplotlib/ipympl#usage) only as `%matplotlib widget`.   
It would be nice if it was consistent and explicit as I see users posting as if `%matplotlib ipympl` and `%matplotlib widget` are distinct, despite modern Jupyter needing `ipympl`.