### PR TITLE
build: update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,16 +15,14 @@ jobs:
       with:
         environment-name: ipympl-release
         create-args: >-
-          python=3.9
-          jupyterlab
+          python=3.12
           yarn
-          matplotlib
           ipywidgets
-          jupyter-packaging=0.7
+          jupyterlab
 
     - name: Install dependencies
       run: |
-        python -m pip install twine wheel build
+        python -m pip install twine wheel build "packaging>=24.2"
 
     - name: Publish the Python package
       env:


### PR DESCRIPTION
It broke on previous release. Updating the requirements to a set that worked for me I manually built an released 0.9.7 

the requirement for packaging is due to https://github.com/pypa/twine/issues/1216