### PR TITLE
bug_report.md: Use set -x and use `;` instead of `&&`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,7 +17,7 @@ In general, please make sure you are using the latest versions of software when 
 Please include the result of the following command, which will print out the version of python, ipympl and the Jupyter ecosystem.
 
 ```bash
-python -c "import sys; print('\n',sys.version); import ipympl; print('ipympl version:', ipympl.__version__)" && jupyter --version && jupyter nbextension list && jupyter labextension list
+set -x ; python -c "import sys; print('\n',sys.version); import ipympl; print('ipympl version:', ipympl.__version__)" ; jupyter --version ; jupyter nbextension list ; jupyter labextension list
 ```
 -->
 ```


### PR DESCRIPTION
set -x shows the command in the output, making the output's respective command clearer. Using `;` rather than `&&` also runs the other commands even if one fails, for example if "jupyter-nbextension" is not found.