### PR TITLE
Use intersphinx_registry to keep intersphinx_mapping up to date.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@ import inspect
 #
 import os
 import sys
+from intersphinx_registry import get_intersphinx_mapping
 
 try:
     from ipympl import __version__ as release
@@ -50,12 +51,9 @@ primary_domain = "py"
 nitpicky = True  # warn if cross-references are missing
 
 # Intersphinx settings
-intersphinx_mapping = {
-    "ipywidgets": ("https://ipywidgets.readthedocs.io/en/stable", None),
-    "matplotlib": ("https://matplotlib.org/stable", None),
-    "numpy": ("https://numpy.org/doc/stable", None),
-    "python": ("https://docs.python.org/3", None),
-}
+intersphinx_mapping = get_intersphinx_mapping(
+    packages={"ipywidgets", "matplotlib", "numpy", "python"}
+)
 
 
 # Settings for copybutton

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ docs = [
     "sphinx-copybutton",
     "sphinx-thebe",
     "sphinx-togglebutton",
+    "intersphinx_registry",
 ]
 
 [project.urls]


### PR DESCRIPTION
This makes sure that the intersphinx_mapping is up to date with the latest packages, and allow to
update URLs in a single place.